### PR TITLE
built_redux example - consume flutter_built_redux 0.4.0

### DIFF
--- a/example/built_redux/lib/containers/action_selector.dart
+++ b/example/built_redux/lib/containers/action_selector.dart
@@ -4,8 +4,7 @@ import 'package:built_redux_sample/presentation/extra_actions_button.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_built_redux/flutter_built_redux.dart';
 
-class ExtraActionSelector
-    extends StoreConnector<AppState, AppStateBuilder, AppActions, bool> {
+class ExtraActionSelector extends StoreConnector<AppState, AppActions, bool> {
   ExtraActionSelector({Key key}) : super(key: key);
 
   @override

--- a/example/built_redux/lib/containers/active_tab.dart
+++ b/example/built_redux/lib/containers/active_tab.dart
@@ -5,8 +5,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_built_redux/flutter_built_redux.dart';
 
-class ActiveTab
-    extends StoreConnector<AppState, AppStateBuilder, AppActions, AppTab> {
+class ActiveTab extends StoreConnector<AppState, AppActions, AppTab> {
   final ViewModelBuilder<AppTab> builder;
 
   ActiveTab({Key key, @required this.builder}) : super(key: key);

--- a/example/built_redux/lib/containers/add_todo.dart
+++ b/example/built_redux/lib/containers/add_todo.dart
@@ -4,8 +4,7 @@ import 'package:built_redux_sample/presentation/add_edit_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_built_redux/flutter_built_redux.dart';
 
-class AddTodo
-    extends StoreConnector<AppState, AppStateBuilder, AppActions, Null> {
+class AddTodo extends StoreConnector<AppState, AppActions, Null> {
   AddTodo({Key key}) : super(key: key);
 
   @override

--- a/example/built_redux/lib/containers/app_loading.dart
+++ b/example/built_redux/lib/containers/app_loading.dart
@@ -5,8 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_built_redux/flutter_built_redux.dart';
 
-class AppLoading
-    extends StoreConnector<AppState, AppStateBuilder, AppActions, bool> {
+class AppLoading extends StoreConnector<AppState, AppActions, bool> {
   final ViewModelBuilder<bool> builder;
 
   AppLoading({Key key, @required this.builder}) : super(key: key);

--- a/example/built_redux/lib/containers/edit_todo.dart
+++ b/example/built_redux/lib/containers/edit_todo.dart
@@ -18,10 +18,9 @@ class EditTodo extends StoreConnector<AppState, AppActions, Null> {
       onSave: (task, note) {
         actions.updateTodoAction(new UpdateTodoActionPayload(
             todo.id,
-            (todo.toBuilder()
-                  ..task = task
-                  ..note = note)
-                .build()));
+            todo.rebuild((b) => b
+              ..task = task
+              ..note = note)));
       },
       todo: todo,
     );

--- a/example/built_redux/lib/containers/edit_todo.dart
+++ b/example/built_redux/lib/containers/edit_todo.dart
@@ -5,8 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_architecture_samples/flutter_architecture_samples.dart';
 import 'package:flutter_built_redux/flutter_built_redux.dart';
 
-class EditTodo
-    extends StoreConnector<AppState, AppStateBuilder, AppActions, Null> {
+class EditTodo extends StoreConnector<AppState, AppActions, Null> {
   final Todo todo;
 
   EditTodo({this.todo, Key key}) : super(key: key);

--- a/example/built_redux/lib/containers/filter_selector.dart
+++ b/example/built_redux/lib/containers/filter_selector.dart
@@ -35,8 +35,8 @@ abstract class FilterSelectorViewModel
   }
 }
 
-class FilterSelector extends StoreConnector<AppState, AppStateBuilder,
-    AppActions, VisibilityFilter> {
+class FilterSelector
+    extends StoreConnector<AppState, AppActions, VisibilityFilter> {
   final ViewModelBuilder<FilterSelectorViewModel> builder;
 
   @override

--- a/example/built_redux/lib/containers/filtered_todos.dart
+++ b/example/built_redux/lib/containers/filtered_todos.dart
@@ -13,7 +13,7 @@ class FilteredTodos extends StoreConnector<AppState, AppActions, List<Todo>> {
       todos: state,
       onCheckboxChanged: (todo, complete) {
         actions.updateTodoAction(new UpdateTodoActionPayload(
-            todo.id, (todo.toBuilder()..complete = complete).build()));
+            todo.id, todo.rebuild((b) => b..complete = complete)));
       },
       onRemove: (todo) {
         actions.deleteTodoAction(todo.id);

--- a/example/built_redux/lib/containers/filtered_todos.dart
+++ b/example/built_redux/lib/containers/filtered_todos.dart
@@ -4,8 +4,7 @@ import 'package:built_redux_sample/presentation/todo_list.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_built_redux/flutter_built_redux.dart';
 
-class FilteredTodos
-    extends StoreConnector<AppState, AppStateBuilder, AppActions, List<Todo>> {
+class FilteredTodos extends StoreConnector<AppState, AppActions, List<Todo>> {
   FilteredTodos({Key key}) : super(key: key);
 
   @override

--- a/example/built_redux/lib/containers/stats.dart
+++ b/example/built_redux/lib/containers/stats.dart
@@ -19,8 +19,7 @@ abstract class StatsProps implements Built<StatsProps, StatsPropsBuilder> {
   factory StatsProps([updates(StatsPropsBuilder b)]) = _$StatsProps;
 }
 
-class Stats
-    extends StoreConnector<AppState, AppStateBuilder, AppActions, StatsProps> {
+class Stats extends StoreConnector<AppState, AppActions, StatsProps> {
   Stats({Key key}) : super(key: key);
 
   @override

--- a/example/built_redux/lib/containers/tab_selector.dart
+++ b/example/built_redux/lib/containers/tab_selector.dart
@@ -7,8 +7,7 @@ import 'package:flutter_built_redux/flutter_built_redux.dart';
 
 typedef OnTabsSelected = void Function(int);
 
-class TabSelector
-    extends StoreConnector<AppState, AppStateBuilder, AppActions, AppTab> {
+class TabSelector extends StoreConnector<AppState, AppActions, AppTab> {
   TabSelector({Key key}) : super(key: key);
 
   @override
@@ -31,7 +30,7 @@ class TabSelector
                 : ArchSampleKeys.todoTab,
           ),
           title: new Text(tab == AppTab.stats
-              ? ArchSampleLocalizations.of(context).stats
+              ? 'ArchSampleLocalizations.of(context).stats'
               : ArchSampleLocalizations.of(context).todos),
         );
       }).toList(),

--- a/example/built_redux/lib/containers/tab_selector.dart
+++ b/example/built_redux/lib/containers/tab_selector.dart
@@ -30,7 +30,7 @@ class TabSelector extends StoreConnector<AppState, AppActions, AppTab> {
                 : ArchSampleKeys.todoTab,
           ),
           title: new Text(tab == AppTab.stats
-              ? 'ArchSampleLocalizations.of(context).stats'
+              ? ArchSampleLocalizations.of(context).stats
               : ArchSampleLocalizations.of(context).todos),
         );
       }).toList(),

--- a/example/built_redux/lib/containers/todo_details.dart
+++ b/example/built_redux/lib/containers/todo_details.dart
@@ -18,7 +18,7 @@ class TodoDetails extends StoreConnector<AppState, AppActions, Todo> {
       toggleCompleted: (isComplete) {
         actions.updateTodoAction(new UpdateTodoActionPayload(
           id,
-          (todo.toBuilder()..complete = isComplete).build(),
+          todo.rebuild((b) => b..complete = isComplete),
         ));
       },
     );

--- a/example/built_redux/lib/containers/todo_details.dart
+++ b/example/built_redux/lib/containers/todo_details.dart
@@ -5,8 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_built_redux/flutter_built_redux.dart';
 
-class TodoDetails
-    extends StoreConnector<AppState, AppStateBuilder, AppActions, Todo> {
+class TodoDetails extends StoreConnector<AppState, AppActions, Todo> {
   final String id;
 
   TodoDetails({Key key, @required this.id}) : super(key: key);

--- a/example/built_redux/lib/reducers/reducers.dart
+++ b/example/built_redux/lib/reducers/reducers.dart
@@ -29,9 +29,7 @@ void deleteTodo(
 
 void toggleAll(AppState state, Action<Null> action, AppStateBuilder builder) {
   final allComplete = state.allCompleteSelector;
-
-  builder.todos = state.todos.toBuilder()
-    ..map((todo) => (todo.toBuilder()..complete = !allComplete).build());
+  builder.todos.map((todo) => todo.rebuild((b) => b..complete = !allComplete));
 }
 
 void updateFilter(

--- a/example/built_redux/pubspec.yaml
+++ b/example/built_redux/pubspec.yaml
@@ -4,10 +4,11 @@ description: An example Todo app created with built_redux
 dependencies:
   flutter:
     sdk: flutter
-  flutter_built_redux: 0.3.0
+  flutter_built_redux:
+    path: ../../../flutter_built_redux
   built_redux: ^7.0.0
   built_value: ^4.3.2
-  built_collection: ^1.3.0
+  built_collection: ^2.0.0
   flutter_architecture_samples:
     path: ../../
 

--- a/example/built_redux/pubspec.yaml
+++ b/example/built_redux/pubspec.yaml
@@ -4,8 +4,7 @@ description: An example Todo app created with built_redux
 dependencies:
   flutter:
     sdk: flutter
-  flutter_built_redux:
-    path: ../../../flutter_built_redux
+  flutter_built_redux: ^0.4.0
   built_redux: ^7.0.0
   built_value: ^4.3.2
   built_collection: ^2.0.0

--- a/example/built_redux/test/reducer_test.dart
+++ b/example/built_redux/test/reducer_test.dart
@@ -36,7 +36,7 @@ main() {
 
     test('should update a todo in response to an UpdateTodoAction', () {
       final todo = new Todo("Hallo");
-      final updatedTodo = (todo.toBuilder()..task = "Tschuss").build();
+      final updatedTodo = todo.rebuild((b) => b.task = "Tschuss");
       final store = new Store<AppState, AppStateBuilder, AppActions>(
         reducerBuilder.build(),
         new AppState.fromTodos([todo]),

--- a/lib/src/localizations/messages_all.dart
+++ b/lib/src/localizations/messages_all.dart
@@ -8,7 +8,7 @@ import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
 import 'package:intl/src/intl_helpers.dart';
 
-import 'messages_en.dart' deferred as messages_en;
+import 'messages_en.dart' as messages_en;
 
 typedef Future<dynamic> LibraryLoader();
 Map<String, LibraryLoader> _deferredLibraries = {


### PR DESCRIPTION
- Updated flutter_built_redux dependency to 0.4.0
  - Remove builder generic from containers, as this generic is no longer necessary in 0.4.0
- Update usages of toBuilder() -> build() to use rebuild()
- Remove deferred import of messages_en, as it caused issues with hot reloading