### PR TITLE
Allow scoped_model to use more recent versions of mockito

### DIFF
--- a/example/integration_tests/README.md
+++ b/example/integration_tests/README.md
@@ -11,6 +11,10 @@ The Integration (aka end to end tests) that should be run against every sample a
 
 In order to run tests on against your app, you need to use the `flutter_driver`. This tool allows you to find Widgets on screen and send commands to them. This allows you to tap on Widgets, scroll through lists, or get the text of a Text Widget.
 
+To run the tests
+  1. cd example/\<app>/ (e.g. `cd example/vanilla/`)
+  2. flutter drive --target test_driver/todo_app.dart
+
 To get started with Flutter Driver, please check out the following links:
 
   * [How to write an integration test in Flutter](http://cogitas.net/write-integration-test-flutter/) by [Natalie Masse Hooper](https://twitter.com/NatJM)    

--- a/example/scoped_model/pubspec.yaml
+++ b/example/scoped_model/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   cupertino_icons: ^0.1.0
 
 dev_dependencies:
-  mockito: 2.2.0
+  mockito: ^2.2.0
   test: ^0.12.0
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Hi Brian,

Thanks for http://fluttersamples.com/ !

example/scoped_model wouldn't run because a specific version for the mockito dependency was specified.