### PR TITLE
Updated for Flutter Beta 0.3.2 & latest Firebase packages

### DIFF
--- a/example/firebase_flutter_repository/lib/reactive_todos_repository.dart
+++ b/example/firebase_flutter_repository/lib/reactive_todos_repository.dart
@@ -28,7 +28,7 @@ class FirestoreReactiveTodosRepository implements ReactiveTodosRepository {
 
   @override
   Stream<List<TodoEntity>> todos() {
-    return firestore.collection(path).snapshots.map((snapshot) {
+    return firestore.collection(path).snapshots().map((snapshot) {
       return snapshot.documents.map((doc) {
         return TodoEntity(
           doc['task'],

--- a/example/firebase_flutter_repository/pubspec.yaml
+++ b/example/firebase_flutter_repository/pubspec.yaml
@@ -6,8 +6,8 @@ dependencies:
     sdk: flutter
   todos_repository:
     path: ../todos_repository
-  firebase_auth: 0.5.3
-  cloud_firestore: 0.5.1
+  firebase_auth: 0.5.9
+  cloud_firestore: 0.7.0
 
 dev_dependencies:
   mockito: ">=2.2.0 <3.0.0"

--- a/example/firestore_redux/android/build.gradle
+++ b/example/firestore_redux/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath 'com.google.gms:google-services:3.1.0'
+        classpath 'com.google.gms:google-services:3.2.1'
     }
 }
 

--- a/example/firestore_redux/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/firestore_redux/ios/Runner.xcodeproj/project.pbxproj
@@ -234,11 +234,11 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-resources.sh",
-				"$PODS_CONFIGURATION_BUILD_DIR/gRPC/gRPCCertificates.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/gRPC/gRPCCertificates.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/gRPCCertificates.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
Appears that Flutter Beta 0.3.2 w/ latest firebase_auth & cloud_firestore works successfully even with google-services 3.1.0. I went ahead and updated the repo to google services 3.2.1 since there was a breaking change on cloud_firestore 0.7.0, see [changelog](https://pub.dartlang.org/packages/cloud_firestore#-changelog-tab-). Tests all pass.