### PR TITLE
Update Redurx README with more neutral description

### DIFF
--- a/example/redurx/README.md
+++ b/example/redurx/README.md
@@ -10,17 +10,32 @@ An example Todo app created with [built_value](https://pub.dartlang.org/packages
   * **Actions** holds it's own **reducers** and can be Asynchronous through **AsyncActions** 
   * **Middlewares** can act *before* and *after* Actions, note that for `AsyncActions` it calls `beforeAction` twice, one for before async execution and other for completed async execution, but before State rebuilding ([#3](https://github.com/leocavalcante/Flutter-ReduRx/issues/3))
   * **Connect** is composable as any other Widget, not some class you should extend.
-  
-## Dependency injection
-  
-You can use Middlewares to inject dependencies on Actions. A good call is to use [mixins](https://www.dartlang.org/articles/language/mixins) so you can type-safely call [setter injectors](https://en.wikipedia.org/wiki/Dependency_injection#Setter_injection_comparison). That is how we make `FetchTodos` action aware about `TodosRepository`.
-  
-## Differences to other implementations
-
-It's a little layer above the [StreamBuilder](https://docs.flutter.io/flutter/widgets/StreamBuilder-class.html) using [RxDart](https://github.com/ReactiveX/rxdart), there's not much magic going on without your knowledge in Flutter vanilla. This is a biased comment since I am the author of this implementation, but I believe it is the most pragmatic way among the other solutions without any loss of performance or maintainability.
-
-With a few lines of code you already have reactive components, all your State anytime you have a `BuildContext` and full control over when they should be update avoiding any unnecessary rebuild.
 
 ## Testing
 
 There is no special treatment to test your Widgets, they are composed inside the `Connect` like it would be on any `WidgetBuilder`, but with it's sub-state instead of a `context`, this sub-state can be freely mocked as simple plain-old Dart code.
+
+## Differences to Redux
+
+These two libraries are very similar since they're both based on ReduxJS. These are the differences:
+
+  * Actions
+    - `redurx` - Actions describe how the state should change
+    - `Redux` - Actions are plain ol' Dart values, Classes or Enums. Could optionally create an Action type that describes how the state should change.
+  * Reducers
+    - `redurx` - No reducers! Handled inside the actions.
+    - `redux` - A function that takes in the current app state and the latest action and return a new app state.
+  * Async code / side effects
+    - Use `AsyncActions` and `Middleware` to perform async work / side-effects
+    - Use `Middleware`, `redux_epics`, or `redux_thunk` (very similar to `AsyncActions`)
+  * Middleware
+    - Slight API differences
+    - Both allow you to listen for specific actions and perform work based on those actions
+  * Flutter integration
+    - Both 
+        - Convert the latest state of the Store into a Widget
+        - Allow you to filter which state changes result in a Widget rebuild
+    - `flutter_redux` - currently offers a few additional utilities, such as `onInit`, `onDispose` and `onWillChange` callbacks for `StoreConverters`.
+  * Dependency Injection
+    - `redurx` - You can use Middlewares to inject dependencies on Actions. A good call is to use [mixins](https://www.dartlang.org/articles/language/mixins) so you can type-safely call [setter injectors](https://en.wikipedia.org/wiki/Dependency_injection#Setter_injection_comparison). That is how we make `FetchTodos` action aware about `TodosRepository`.
+    - `redux` - Instantiate all Middleware with their dependencies when they're created


### PR DESCRIPTION
@leocavalcante Hey hey :) We got an email where I think there was some confusion about this README.

Therefore, I'd like to update the README to describe the differences between the two libs. My goal: describe the differences between the two libs in a neutral voice so the end-user can understand the trade-offs each library has made, similar to what I've got with the `built_redux` example.

Please let me know if you like these changes, or if there are parts you disagree with!

