### PR TITLE
use git import in todos_repository_simple

### DIFF
--- a/todos_repository_simple/pubspec.yaml
+++ b/todos_repository_simple/pubspec.yaml
@@ -8,7 +8,9 @@ dependencies:
   flutter:
     sdk: flutter
   todos_repository_core:
-    path: ../todos_repository_core
+    git:
+      url: https://github.com/brianegan/flutter_architecture_samples
+      path: todos_repository_core
   rxdart: ^0.18.0
 
 dev_dependencies:


### PR DESCRIPTION
It'd be nice to be able to import repositories from other projects like:

```yaml
name: flutter_todos
description: A new Flutter project.

 environment:
  sdk: ">=2.0.0 <3.0.0"

 dependencies:
  flutter:
    sdk: flutter
  todos_app_core:
    git:
      url: https://github.com/brianegan/flutter_architecture_samples
      path: todos_app_core
  todos_repository_core:
    git:
      url: https://github.com/brianegan/flutter_architecture_samples
      path: todos_repository_core
  todos_repository_simple:
    git:
      url: https://github.com/brianegan/flutter_architecture_samples
      path: todos_repository_simple
  
 flutter:
  uses-material-design: true 
```

but because the `todos_repository_simple` pubspec references the `todos_repository_core` using a relative import it seems like this is not possible.