### PR TITLE
update to flutter_bloc 0.14.0 override rxdart version

### DIFF
--- a/bloc_library/lib/blocs/simple_bloc_delegate.dart
+++ b/bloc_library/lib/blocs/simple_bloc_delegate.dart
@@ -8,14 +8,14 @@ import 'package:bloc/bloc.dart';
 // in order to handle transitions and errors from all Blocs.
 class SimpleBlocDelegate extends BlocDelegate {
   @override
-  void onTransition(Transition transition) {
-    super.onTransition(transition);
+  void onTransition(Bloc bloc, Transition transition) {
+    super.onTransition(bloc, transition);
     print(transition);
   }
 
   @override
-  void onError(Object error, StackTrace stacktrace) {
-    super.onError(error, stacktrace);
+  void onError(Bloc bloc, Object error, StackTrace stacktrace) {
+    super.onError(bloc, error, stacktrace);
     print(error);
   }
 }

--- a/bloc_library/lib/main.dart
+++ b/bloc_library/lib/main.dart
@@ -17,7 +17,7 @@ void main() {
   // BlocSupervisor oversees Blocs and delegates to BlocDelegate.
   // We can set the BlocSupervisor's delegate to an instance of `SimpleBlocDelegate`.
   // This will allow us to handle all transitions and errors in SimpleBlocDelegate.
-  BlocSupervisor().delegate = SimpleBlocDelegate();
+  BlocSupervisor.delegate = SimpleBlocDelegate();
   runApp(BlocApp());
 }
 

--- a/bloc_library/pubspec.yaml
+++ b/bloc_library/pubspec.yaml
@@ -7,24 +7,18 @@ environment:
 dependencies:
   meta: ">=1.1.0 <2.0.0"
   equatable: ^0.2.0
-  flutter_bloc: ^0.10.0
+  flutter_bloc: ^0.14.0
+  todos_app_core:
+    path: ../todos_app_core
+  todos_repository_simple:
+    path: ../todos_repository_simple
   flutter:
     sdk: flutter
 
 dependency_overrides:
-  todos_app_core:
-    git:
-      url: https://github.com/felangel/flutter_architecture_samples
-      path: todos_app_core
-      ref: expose-repositories
-  todos_repository_simple:
-    git:
-      url: https://github.com/felangel/flutter_architecture_samples
-      path: todos_repository_simple
-      ref: expose-repositories
+  rxdart: ^0.22.0
 
 dev_dependencies:
-  test: ^1.3.0
   mockito: ^3.0.0
   flutter_driver:
     sdk: flutter

--- a/bloc_library/test/blocs/simple_bloc_delegate_test.dart
+++ b/bloc_library/test/blocs/simple_bloc_delegate_test.dart
@@ -3,23 +3,29 @@
 // in the LICENSE file.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:bloc_library/blocs/simple_bloc_delegate.dart';
 import 'package:bloc/bloc.dart';
 import 'dart:async';
+
+class MockBloc extends Mock implements Bloc {}
 
 var printLog;
 
 main() {
   group('SimpleBlocDelegate', () {
     SimpleBlocDelegate delegate;
+    MockBloc bloc;
 
     setUp(() {
       delegate = SimpleBlocDelegate();
+      bloc = MockBloc();
       printLog = [];
     });
 
     test('onTransition prints Transition', overridePrint(() {
       delegate.onTransition(
+        bloc,
         Transition(currentState: 'A', event: 'E', nextState: 'B'),
       );
       expect(
@@ -29,7 +35,7 @@ main() {
     }));
 
     test('onError prints Error', overridePrint(() {
-      delegate.onError('whoops', null);
+      delegate.onError(bloc, 'whoops', null);
       expect(
         printLog[0],
         'whoops',


### PR DESCRIPTION
- Addresses rxdart compat issue discussed in #136 
- Update to `flutter_bloc ^0.14.0` 