### PR TITLE
Pinned flutter on cirrus to v1.2.1 because of timeout on unit tests on v1.5.4-hotfix.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,10 +1,13 @@
 timeout_in: 30m
+env:
+  FLUTTER_CHANNEL: stable
+  FLUTTER_VERSION: v1.2.1
 
 task:
   # this task should fail fast or rely on 'depends_on' for all other tasks
   name: Tests (Unit)
   container:
-    image: cirrusci/flutter:latest
+    image: cirrusci/flutter:$FLUTTER_VERSION
   pub_cache:
     folder: ~/.pub-cache
   activate_coverage_script: pub global activate coverage
@@ -34,7 +37,7 @@ task:
       app_arch: simple_bloc_flutter
       app_arch: vanilla
   container:
-    image: cirrusci/flutter:latest
+    image: cirrusci/flutter:$FLUTTER_VERSION
   allow_failures: $app_arch == "mvu" || $app_arch == "redurx"
   pin_emulator_script:
     # Download a pinned version of the emulator since upgrades can cause issues
@@ -90,6 +93,14 @@ task:
     - udid=$(xcrun simctl create "iPhone X" com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-12-0)
     # boot simulator
     - xcrun simctl boot $udid
+  pin_flutter_script:
+    - flutter --version
+    # pin to ${FLUTTER_VERSION}
+    - wget --quiet --output-document=flutter.zip https://storage.googleapis.com/flutter_infra/releases/${FLUTTER_CHANNEL}/macos/flutter_macos_${FLUTTER_VERSION}-${FLUTTER_CHANNEL}.zip && unzip -qq flutter.zip > /dev/null && rm flutter.zip
+    - export PATH="$PATH":"$HOME/.pub-cache/bin"
+    - export PATH=$PWD/flutter/bin:$PWD/flutter/bin/cache/dart-sdk/bin:$PATH
+    - flutter precache
+    - flutter --version
   doctor_script: flutter doctor -v
   devices_script: flutter devices
   ci_script: ./scripts/ci.sh ./$app_arch || ./scripts/ci.sh ./$app_arch

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -68,7 +68,6 @@ task:
   only_if: $CIRRUS_PR == ''
   skip: '!changesInclude(".cirrus.yml", "$app_arch/*", "$app_arch/**/*")'
   env:
-    PATH: $HOME/.pub-cache/bin:$PWD/flutter/bin:$PWD/flutter/bin/cache/dart-sdk/bin:$PATH
     matrix:
       app_arch: bloc_flutter
       app_arch: bloc_library
@@ -98,8 +97,19 @@ task:
     - flutter --version
     # pin to ${FLUTTER_VERSION}
     - wget --quiet --output-document=flutter.zip https://storage.googleapis.com/flutter_infra/releases/${FLUTTER_CHANNEL}/macos/flutter_macos_${FLUTTER_VERSION}-${FLUTTER_CHANNEL}.zip && unzip -qq flutter.zip > /dev/null && rm flutter.zip
+    - export PATH="$PATH":"$HOME/.pub-cache/bin"
+    - export PATH=$PWD/flutter/bin:$PWD/flutter/bin/cache/dart-sdk/bin:$PATH
     - flutter precache
     - flutter --version
-  doctor_script: flutter doctor -v
-  devices_script: flutter devices
-  ci_script: ./scripts/ci.sh ./$app_arch || ./scripts/ci.sh ./$app_arch
+  doctor_script:
+    - export PATH="$PATH":"$HOME/.pub-cache/bin"
+    - export PATH=$PWD/flutter/bin:$PWD/flutter/bin/cache/dart-sdk/bin:$PATH
+    - flutter doctor -v
+  devices_script:
+    - export PATH="$PATH":"$HOME/.pub-cache/bin"
+    - export PATH=$PWD/flutter/bin:$PWD/flutter/bin/cache/dart-sdk/bin:$PATH
+    - flutter devices
+  ci_script:
+    - export PATH="$PATH":"$HOME/.pub-cache/bin"
+    - export PATH=$PWD/flutter/bin:$PWD/flutter/bin/cache/dart-sdk/bin:$PATH
+    - ./scripts/ci.sh ./$app_arch || ./scripts/ci.sh ./$app_arch

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -68,7 +68,7 @@ task:
   only_if: $CIRRUS_PR == ''
   skip: '!changesInclude(".cirrus.yml", "$app_arch/*", "$app_arch/**/*")'
   env:
-    PATH: "$HOME/.pub-cache/bin":$PWD/flutter/bin:$PWD/flutter/bin/cache/dart-sdk/bin:$PATH
+    PATH: $HOME/.pub-cache/bin:$PWD/flutter/bin:$PWD/flutter/bin/cache/dart-sdk/bin:$PATH
     matrix:
       app_arch: bloc_flutter
       app_arch: bloc_library

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -68,6 +68,7 @@ task:
   only_if: $CIRRUS_PR == ''
   skip: '!changesInclude(".cirrus.yml", "$app_arch/*", "$app_arch/**/*")'
   env:
+    PATH: "$HOME/.pub-cache/bin":$PWD/flutter/bin:$PWD/flutter/bin/cache/dart-sdk/bin:$PATH
     matrix:
       app_arch: bloc_flutter
       app_arch: bloc_library
@@ -97,8 +98,6 @@ task:
     - flutter --version
     # pin to ${FLUTTER_VERSION}
     - wget --quiet --output-document=flutter.zip https://storage.googleapis.com/flutter_infra/releases/${FLUTTER_CHANNEL}/macos/flutter_macos_${FLUTTER_VERSION}-${FLUTTER_CHANNEL}.zip && unzip -qq flutter.zip > /dev/null && rm flutter.zip
-    - export PATH="$PATH":"$HOME/.pub-cache/bin"
-    - export PATH=$PWD/flutter/bin:$PWD/flutter/bin/cache/dart-sdk/bin:$PATH
     - flutter precache
     - flutter --version
   doctor_script: flutter doctor -v


### PR DESCRIPTION
Timeout is possibly related to code coverage
Flutter version should be updated to latest version (currently v1.5.4-hotfix.2). This will involve resolving timeout issue and updating libraries in several projects.